### PR TITLE
fix: normalize repository URL for sigstore provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/neovici/testing.git"
+		"url": "https://github.com/Neovici/testing"
 	},
 	"license": "Apache-2.0",
 	"author": "",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
 		"haunted",
 		"pion"
 	],
-	"homepage": "https://github.com/neovici/testing#readme",
+	"homepage": "https://github.com/Neovici/testing#readme",
 	"bugs": {
-		"url": "https://github.com/neovici/testing/issues"
+		"url": "https://github.com/Neovici/testing/issues"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary

Fix the repository URL in  to match the expected format from sigstore provenance:
- Changed  to  (case sensitivity)
- Removed  prefix
- Removed  suffix

This resolves the sigstore provenance verification error when publishing.