### PR TITLE
feat: add .js extensions for Node.js ESM compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
-export * from './render-hook';
-export * from './wait-until';
+// Use .js extensions for Node.js ESM compatibility
+// See: https://www.typescriptlang.org/docs/handbook/modules/guides/choosing-compiler-options.html#im-writing-a-library
+export * from './render-hook.js';
+export * from './wait-until.js';

--- a/src/render-hook.ts
+++ b/src/render-hook.ts
@@ -1,7 +1,7 @@
-import { mkResult, type RenderResult } from './result';
-import { mkRenderer } from './renderer';
-import { waitUntil } from './wait-until';
-import type { RenderHookOptions } from './types';
+import { mkResult, type RenderResult } from './result.js';
+import { mkRenderer } from './renderer.js';
+import { waitUntil } from './wait-until.js';
+import type { RenderHookOptions } from './types.js';
 
 const tillNextUpdate =
 	<T>(addResolver: ReturnType<typeof mkResult<T>>['addResolver']) =>

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,4 +1,4 @@
-import { RendererProps, Wrapper } from './types';
+import { RendererProps, Wrapper } from './types.js';
 import { component } from '@pionjs/pion';
 import { unsafeStatic, html } from 'lit-html/static.js';
 import { render as litRender, TemplateResult } from 'lit-html';

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,4 +1,4 @@
-import type { RenderResult } from './types';
+import type { RenderResult } from './types.js';
 
 export type { RenderResult };
 


### PR DESCRIPTION
## Summary
- Add explicit `.js` extensions to all local imports in TypeScript source files
- Ensures the compiled output works correctly in Node.js ESM environments (e.g., Vitest with `moduleResolution: 'bundler'`)

## Problem
When using `@neovici/testing` in a Vitest unit test environment (jsdom), the following error occurs:
```
Error: Failed to resolve import "./result" from "node_modules/@neovici/testing/dist/render-hook.js"
```

This happens because Node.js ESM requires explicit file extensions in imports, but the compiled TypeScript output was missing them.

## Solution
Following the [TypeScript recommendation for libraries](https://www.typescriptlang.org/docs/handbook/modules/guides/choosing-compiler-options.html#im-writing-a-library), we add `.js` extensions to all local imports in the source files. TypeScript preserves these extensions in the output, making the package compatible with both bundlers AND Node.js ESM.

## Changes
- `src/index.ts` - Added `.js` extensions + documentation comment
- `src/render-hook.ts` - Added `.js` extensions to imports
- `src/renderer.ts` - Added `.js` extension to import
- `src/result.ts` - Added `.js` extension to import

## Testing
- ✅ `npm run lint` passes
- ✅ `npm run build` produces output with `.js` extensions
- ✅ `npm test` passes (14 tests)

Fixes NEO-935